### PR TITLE
Add output pulse shaping: fix the Gaussian kernel and add a bipolar fast-output mode

### DIFF
--- a/examples/python/simspad.py
+++ b/examples/python/simspad.py
@@ -16,19 +16,31 @@ PARAM_KEYS = [
     "pdeMax", "vChr", "cCell", "tauFwhm", "digitalThreshold",
 ]
 
+# Optional parameters with their defaults (absent keys keep the default on
+# both sides, so files without them remain valid). tauLoad is the fast-output
+# rail RC time constant in seconds, used by the `fast`/`bench` shape modes.
+OPTIONAL_PARAM_DEFAULTS = {
+    "tauLoad": 2.0e-9,
+}
+
 
 class SiPM:
-    def __init__(self, *args):
+    def __init__(self, *args, **optional):
         # SiPM(seq_of_10) or SiPM(dt, numMicrocell, vBias, ...) (10 positional).
         vals = list(args[0]) if len(args) == 1 else list(args)
         if len(vals) != len(PARAM_KEYS):
             raise ValueError(f"expected {len(PARAM_KEYS)} parameters, got {len(vals)}")
         for key, val in zip(PARAM_KEYS, vals):
             setattr(self, key, val)
+        for key, default in OPTIONAL_PARAM_DEFAULTS.items():
+            setattr(self, key, optional.pop(key, default))
+        if optional:
+            raise ValueError(f"unknown optional parameters: {sorted(optional)}")
 
     # -- parameters (JSON) --------------------------------------------------
     def params_dict(self):
         d = {k: getattr(self, k) for k in PARAM_KEYS}
+        d.update({k: getattr(self, k) for k in OPTIONAL_PARAM_DEFAULTS})
         d["numMicrocell"] = int(d["numMicrocell"])
         return d
 
@@ -42,7 +54,8 @@ class SiPM:
         """Construct a SiPM from a JSON parameter file."""
         with open(filename) as f:
             d = json.load(f)
-        return cls([d[k] for k in PARAM_KEYS])
+        optional = {k: d[k] for k in OPTIONAL_PARAM_DEFAULTS if k in d}
+        return cls([d[k] for k in PARAM_KEYS], **optional)
 
     # -- waveforms (.npy) ---------------------------------------------------
     @staticmethod

--- a/makefile
+++ b/makefile
@@ -59,7 +59,7 @@ info:
 	@echo "[*] Dependencies:	${DEPENDENCIES}"
 
 
-test: ./test/test.cpp ./test/performance.hpp ./test/current_accuracy.hpp ./src/sipm.cpp ./src/utilities.cpp
+test: ./test/test.cpp ./test/performance.hpp ./test/current_accuracy.hpp ./test/shaping.hpp ./src/sipm.cpp ./src/utilities.cpp
 	$(CXX) $(CXXFLAGS) -o $(APP_DIR)/$(TARGET_TEST) ./test/test.cpp ./src/sipm.cpp ./src/utilities.cpp
 	./build/apps/test
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -74,9 +74,25 @@ void print_info(chrono::duration<double> elapsed, SiPM &sipm, size_t inputSize, 
 // transform is length-preserving, so the output header is written before its
 // body. Two passes over the (paged) input: one to seed the initial microcell
 // age distribution from the mean light level, one to simulate.
-void simulate(string params_file, string fname_in, string fname_out, bool silence)
+//
+// shapeMode selects optional output pulse shaping (all length-preserving):
+//   none     - bare avalanche charge train (default, unchanged behaviour)
+//   gaussian - Gaussian FIR, FWHM = tauFwhm (an idealised amplifier)
+//   fast     - bipolar fast-output kernel (AC-coupled J-Series fast terminal)
+//   bench    - fast then gaussian: the physical terminal followed by a
+//              ~Gaussian amplifier, i.e. what an oscilloscope capture of the
+//              real device looks like
+// The fast shaper is a pair of recursive one-pole filters, so it streams
+// chunk-by-chunk with its state carried across chunks. The Gaussian is a FIR
+// convolution; rather than handle inter-chunk overlap, modes that need it
+// buffer the full response vector and shape it in one pass (8 bytes per
+// sample of extra memory -- the streaming bound is given up for those modes).
+void simulate(string params_file, string fname_in, string fname_out, bool silence, string shapeMode)
 {
     const size_t chunk = 1u << 16; // 65536 samples per block
+
+    const bool wantFast = (shapeMode == "fast") || (shapeMode == "bench");
+    const bool wantGaussian = (shapeMode == "gaussian") || (shapeMode == "bench");
 
     SiPM sipm = load_params_json(params_file);
     NpyReader reader(fname_in);
@@ -100,20 +116,46 @@ void simulate(string params_file, string fname_in, string fname_out, bool silenc
     double mean = N ? rawSum / (double)N : 0.0;
     sipm.init_state(mean, (unsigned long)N);
 
-    // Pass 2: stream the simulation, writing each output block as it is made.
+    // Pass 2: stream the simulation, writing each output block as it is made
+    // (or buffering it when Gaussian shaping needs the whole trace).
     reader.rewind();
     auto start = chrono::steady_clock::now();
     double outSum = 0.0;
+    vector<double> full; // buffered response, only used when wantGaussian
+    if (wantGaussian)
     {
-        vector<double> inbuf(chunk), outbuf(chunk);
+        full.reserve(N);
+    }
+    if (wantFast)
+    {
+        sipm.reset_fast_shaper();
+    }
+    {
+        vector<double> inbuf(chunk), outbuf(chunk), shapebuf(chunk);
         size_t got, done = 0;
         while ((got = reader.read(inbuf.data(), chunk)) > 0)
         {
             sipm.simulate_chunk(inbuf.data(), outbuf.data(), got);
-            writer.write(outbuf.data(), got);
+            // outSum (-> reported Ibias) is taken before shaping: the bias
+            // current is an anode quantity, and the fast output integrates
+            // to ~zero by construction.
             for (size_t i = 0; i < got; i++)
             {
                 outSum += outbuf[i];
+            }
+            const double *res = outbuf.data();
+            if (wantFast)
+            {
+                sipm.shape_fast_chunk(outbuf.data(), shapebuf.data(), got);
+                res = shapebuf.data();
+            }
+            if (wantGaussian)
+            {
+                full.insert(full.end(), res, res + got);
+            }
+            else
+            {
+                writer.write(res, got);
             }
             done += got;
             if (!silence && N)
@@ -125,6 +167,12 @@ void simulate(string params_file, string fname_in, string fname_out, bool silenc
         {
             fprintf(stderr, "\r  simulating... done   \n");
         }
+    }
+    if (wantGaussian)
+    {
+        // Length-preserving "same" convolution; see conv1d() for alignment.
+        vector<double> shaped = conv1d(full, get_gaussian(sipm.dt, sipm.tauFwhm));
+        writer.write(shaped.data(), shaped.size());
     }
     writer.close();
     auto end = chrono::steady_clock::now();
@@ -156,7 +204,11 @@ static void show_usage(string name)
          << "\t-v,--version\t\tPrint SimSPAD version number\n"
          << "\t-p,--params PARAMS\tDevice parameters (.json) [required]\n"
          << "\t-i,--input INPUT\tOptical input waveform (.npy) [required]\n"
-         << "\t-o,--output OUTPUT\tResponse output path (.npy) [required]"
+         << "\t-o,--output OUTPUT\tResponse output path (.npy) [required]\n"
+         << "\t-S,--shape MODE\t\tOutput pulse shaping: none (default),\n"
+         << "\t\t\t\tgaussian (FWHM = tauFwhm), fast (bipolar AC-coupled\n"
+         << "\t\t\t\tfast-output terminal, tau = tauLoad), or bench\n"
+         << "\t\t\t\t(fast then gaussian, like a real scope capture)"
          << endl;
 }
 
@@ -190,6 +242,7 @@ int main(int argc, char *argv[])
     string params = "";
     string source = "";
     string destination = "";
+    string shapeMode = "none";
     bool silence = false;
 
     // Small helper to consume an option's argument.
@@ -239,6 +292,19 @@ int main(int argc, char *argv[])
                 return EXIT_FAILURE;
             destination = a;
         }
+        else if ((arg == "-S") || (arg == "--shape"))
+        {
+            const char *a = take_arg(i, "--shape");
+            if (!a)
+                return EXIT_FAILURE;
+            shapeMode = a;
+            if (shapeMode != "none" && shapeMode != "gaussian" && shapeMode != "fast" && shapeMode != "bench")
+            {
+                cerr << "error: unknown shape mode '" << shapeMode
+                     << "' (expected none, gaussian, fast or bench)." << endl;
+                return EXIT_FAILURE;
+            }
+        }
         else
         {
             source = argv[i]; // bare positional argument is the input waveform
@@ -259,7 +325,7 @@ int main(int argc, char *argv[])
 
     try
     {
-        simulate(params, source, destination, silence);
+        simulate(params, source, destination, silence, shapeMode);
     }
     catch (const std::exception &e)
     {

--- a/src/sipm.cpp
+++ b/src/sipm.cpp
@@ -232,6 +232,50 @@ vector<double> SiPM::shape_output(vector<double> inputVec)
     return conv1d(inputVec, kernel);
 }
 
+// Fast-output (bipolar) shaping. The J-Series fast terminal is AC-coupled:
+// per detection a fast spike (low-passed by the fast-rail RC tauLoad)
+// followed by an opposite-sign recharge tail (time constant tauRecovery) of
+// equal charge, so the shaped train has zero net charge. The impulse
+// response per unit charge is
+//   h(t) = A * ( e^{-t/tauLoad}/tauLoad - e^{-t/tauRecovery}/tauRecovery ),
+//   A = tauRecovery / (tauRecovery - tauLoad),  integral h dt = 0.
+// Implemented as two exact charge-conserving one-pole recursions
+// (s = a*s + q[i]; out = (1-a)*s, a = e^{-dt/tau}), kept in charge-per-step
+// units so each lobe carries exactly the input charge. Multiply by
+// kappa = C_f/(C_d+C_q) and divide by dt for physical fast-terminal current.
+void SiPM::reset_fast_shaper(void)
+{
+    fastStateLoad = 0.0;
+    fastStateRec = 0.0;
+}
+
+// Shape n charge-per-step samples; filter state persists across calls.
+// States initialise to zero (a fully charged, dark device), so when the
+// simulated device starts in steady state users should discard a warm-up of
+// ~5*tauRecovery from the start of the shaped trace.
+void SiPM::shape_fast_chunk(const double *in, double *out, size_t n)
+{
+    const double aL = exp(-dt / tauLoad);
+    const double aR = exp(-dt / tauRecovery);
+    const double A = tauRecovery / (tauRecovery - tauLoad);
+    for (size_t i = 0; i < n; i++)
+    {
+        fastStateLoad = aL * fastStateLoad + in[i];
+        fastStateRec = aR * fastStateRec + in[i];
+        out[i] = A * ((1.0 - aL) * fastStateLoad - (1.0 - aR) * fastStateRec);
+    }
+}
+
+// One-shot convenience wrapper: reset the filter states and shape a whole
+// charge-per-step vector.
+vector<double> SiPM::shape_fast(vector<double> inputVec)
+{
+    vector<double> out(inputVec.size(), 0.0);
+    reset_fast_shaper();
+    shape_fast_chunk(inputVec.data(), out.data(), inputVec.size());
+    return out;
+}
+
 // Seed Random Engines
 // TODO improve this code - appears to give the same result for all runs within the same second
 void SiPM::seed_engines()
@@ -497,6 +541,14 @@ void SiPM::input_sanitation() // inclusion adds ~ 10ps/ucell dt in SIM
     {
         tauRecovery = 1E-100;
         invalid_argument("Recovery time constant must be strictly positive");
+    }
+    // tauLoad is a divisor in shape_fast_chunk(), and the bipolar gain
+    // A = tauRecovery/(tauRecovery - tauLoad) blows up if the two time
+    // constants coincide. Restore the default in either case.
+    if (tauLoad <= 0 || tauLoad == tauRecovery)
+    {
+        tauLoad = 2.0e-9;
+        invalid_argument("Fast-output load time constant must be strictly positive and differ from tauRecovery");
     }
     if (pdeMax < 0)
     {

--- a/src/sipm.hpp
+++ b/src/sipm.hpp
@@ -57,6 +57,11 @@ public:
     double vChr;
     double pdeMax;
     double tauFwhm;
+    // Fast-output rail RC time constant tau_load = R_L * N * C_f [s].
+    // Optional JSON parameter "tauLoad"; defaults to 2.0e-9 (MicroJ-Series,
+    // 50 ohm load * 40 pF fast-terminal capacitance) so existing parameter
+    // files keep working.
+    double tauLoad = 2.0e-9;
 
     SiPM(unsigned long numMicrocell_in, double vBias_in, double vBr_in, double tauRecovery_in, double tauFwhm_in, double digitalThreshold_in, double ccell_in, double Vchr_in, double PDE_max_in);
 
@@ -91,9 +96,26 @@ public:
 
     std::vector<double> shape_output(std::vector<double> inputVec);
 
+    // Fast-output (bipolar) shaping: models the AC-coupled J-Series fast
+    // terminal as two exact one-pole recursions (O(n), streaming-friendly).
+    // reset_fast_shaper() zeroes the filter states; shape_fast_chunk() then
+    // shapes `n` charge-per-step samples, carrying state across calls so
+    // chunked traces shape identically to one-shot ones. shape_fast(vector)
+    // is a reset + single-chunk convenience wrapper.
+    void reset_fast_shaper(void);
+
+    void shape_fast_chunk(const double *in, double *out, std::size_t n);
+
+    std::vector<double> shape_fast(std::vector<double> inputVec);
+
 private:
     std::vector<double> microcellTimes;
     double simClock = 0.0; // running simulation time, carried across chunks
+
+    // One-pole filter states for the fast-output shaper (charge units),
+    // carried across shape_fast_chunk() calls.
+    double fastStateLoad = 0.0;
+    double fastStateRec = 0.0;
 
     std::mt19937_64 poissonEngine;
     std::mt19937_64 unifRandomEngine;

--- a/src/utilities.cpp
+++ b/src/utilities.cpp
@@ -98,6 +98,14 @@ void write_binary(string filename, SiPM sipm, vector<double> response)
 }
 
 // Output convolve to pulse shape using a gaussian approximation
+//
+// Alignment convention: same-length ("same" mode) output, with the kernel
+// centre kernel[kernelSize/2] aligned to output sample i. get_gaussian()
+// always returns an odd-length symmetric kernel, so the shaped pulse is not
+// time-shifted (for a symmetric kernel, correlation == convolution). Samples
+// that would fall outside the input are treated as zero, so up to
+// kernelSize/2 samples of kernel mass are dropped at each edge -- charge is
+// conserved everywhere except within half a kernel of the trace ends.
 vector<double> conv1d(vector<double> inputVec, vector<double> kernel)
 {
 
@@ -134,32 +142,42 @@ vector<double> conv1d(vector<double> inputVec, vector<double> kernel)
     return outputVec;
 }
 
-// Generate Gaussian kernel
-// TODO check if the pulse width is correct!
+// Generate Gaussian kernel with the requested full width at half maximum.
+// NOTE (sipm-eq-paper): the old conversion used sqrt(2 ln 2)/2 as a *divisor*,
+// making sigma ~4x too large, the loop was asymmetric (off by one at each
+// end), and the kernel was never normalised so convolution did not conserve
+// charge. Correct conversion: FWHM = 2*sqrt(2 ln 2) * sigma.
 vector<double> get_gaussian(double dt, double tauFwhm)
 {
-    const double gaussianConstant = (double)(1 / sqrt(2 * M_PI));
-    const double fwhmConversionConst = sqrt(2 * log(2)) / 2;
-    const double sigma = (tauFwhm / dt) / fwhmConversionConst;
+    const double fwhmConversionConst = 2.0 * sqrt(2.0 * log(2.0)); // FWHM / sigma
+    const double sigma = (tauFwhm / dt) / fwhmConversionConst;     // in samples
     const double numSigma = 4.0;
 
-    int gaussianNumberOfPoints = (int)ceil(numSigma * sigma);
-
-    vector<double> kernel = {};
-    kernel.reserve(gaussianNumberOfPoints * 2);
-
-    if (gaussianNumberOfPoints == 1)
+    // Degenerate widths (non-positive, or too narrow to resolve at this dt)
+    // collapse to the identity kernel.
+    if (!(tauFwhm > 0.0) || sigma < 0.3)
     {
-        kernel.push_back(1);
-        return kernel;
+        return {1.0};
     }
 
-    double gaussianPower;
+    // Symmetric support: i in [-M, +M] inclusive, M = ceil(4 sigma).
+    int M = (int)ceil(numSigma * sigma);
 
-    for (int i = -(gaussianNumberOfPoints - 1); i < (gaussianNumberOfPoints - 1); i++)
+    vector<double> kernel = {};
+    kernel.reserve(2 * M + 1);
+
+    double sum = 0.0;
+    for (int i = -M; i <= M; i++)
     {
-        gaussianPower = -pow((double)i / sigma, 2) / 2;
-        kernel.push_back(gaussianConstant * exp(gaussianPower));
+        double g = exp(-pow((double)i / sigma, 2) / 2);
+        kernel.push_back(g);
+        sum += g;
+    }
+    // Normalise so the discrete sum is exactly 1 (charge conservation); this
+    // supersedes the continuous 1/(sigma sqrt(2 pi)) normalisation constant.
+    for (int j = 0; j < (int)kernel.size(); j++)
+    {
+        kernel[j] /= sum;
     }
     return kernel;
 }
@@ -439,7 +457,20 @@ SiPM load_params_json(const string &filename)
             throw runtime_error(string("params JSON missing key: ") + kParamKeys[i]);
         svars[i] = it->second;
     }
-    return SiPM(svars);
+    SiPM sipm(svars);
+
+    // Optional fast-output load time constant; absent keys keep the default
+    // (2.0e-9 s) so existing parameter files continue to work unchanged.
+    auto tl = m.find("tauLoad");
+    if (tl != m.end())
+    {
+        if (!(tl->second > 0))
+            throw runtime_error("params JSON: tauLoad must be > 0 (seconds)");
+        if (tl->second == sipm.tauRecovery)
+            throw runtime_error("params JSON: tauLoad must differ from tauRecovery");
+        sipm.tauLoad = tl->second;
+    }
+    return sipm;
 }
 
 string sipm_to_json(SiPM &sipm)
@@ -455,8 +486,11 @@ string sipm_to_json(SiPM &sipm)
             o << (unsigned long)c[i]; // numMicrocell as an integer
         else
             o << c[i];
-        o << (i < 9 ? ",\n" : "\n");
+        o << ",\n";
     }
+    // tauLoad is appended explicitly (not via dump_configuration, whose
+    // 10-double layout the legacy .bin format depends on).
+    o << "  \"tauLoad\": " << sipm.tauLoad << "\n";
     o << "}\n";
     return o.str();
 }

--- a/test/shaping.hpp
+++ b/test/shaping.hpp
@@ -1,0 +1,224 @@
+/*
+ * This file is part of the SimSPAD distribution (http://github.com/WillMatthews/SimSPAD).
+ * Copyright (c) 2022 William Matthews.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, version 3.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <iostream>
+#include <iomanip>
+#include <vector>
+#include <string>
+#include <cmath>
+
+#include "../src/sipm.hpp"
+#include "../src/utilities.hpp"
+
+#define BARS 102
+
+using namespace std;
+
+// Measure the FWHM of a discrete kernel (in samples) by linearly
+// interpolating the half-maximum crossings either side of the peak.
+static double kernel_fwhm_samples(const vector<double> &kernel)
+{
+    int peak = 0;
+    for (int i = 0; i < (int)kernel.size(); i++)
+    {
+        if (kernel[i] > kernel[peak])
+        {
+            peak = i;
+        }
+    }
+    double half = kernel[peak] / 2.0;
+
+    // walk left from the peak to the half-maximum crossing
+    double left = 0.0;
+    for (int i = peak; i > 0; i--)
+    {
+        if (kernel[i - 1] < half)
+        {
+            left = (double)(i - 1) + (half - kernel[i - 1]) / (kernel[i] - kernel[i - 1]);
+            break;
+        }
+    }
+    // walk right from the peak to the half-maximum crossing
+    double right = (double)kernel.size() - 1;
+    for (int i = peak; i < (int)kernel.size() - 1; i++)
+    {
+        if (kernel[i + 1] < half)
+        {
+            right = (double)i + (kernel[i] - half) / (kernel[i] - kernel[i + 1]);
+            break;
+        }
+    }
+    return right - left;
+}
+
+// Pulse-shaping unit tests: Gaussian kernel correctness (normalisation and
+// FWHM) and the bipolar fast-output shaper (zero net charge, agreement with
+// the analytic impulse response).
+bool TEST_shaping()
+{
+    string BAR_STRING(BARS, '=');
+    cout << BAR_STRING << endl;
+    cout << "BEGIN TEST: Output Pulse Shaping" << endl;
+    cout << BAR_STRING << endl;
+
+    bool passed_all = true;
+    bool passed;
+    cout << setprecision(6);
+
+    const double dt = 5e-11;
+    const double tauFwhm = 1.5e-9;
+    const double tauRecovery = 30.8e-9;
+    const double tauLoad = 2.0e-9;
+
+    // --- 1. Gaussian kernel: discrete sum exactly 1 (charge conservation) ---
+    vector<double> kernel = get_gaussian(dt, tauFwhm);
+    double sum = 0.0;
+    for (int i = 0; i < (int)kernel.size(); i++)
+    {
+        sum += kernel[i];
+    }
+    passed = fabs(sum - 1.0) < 1e-12;
+    cout << "Gaussian kernel sum:          " << sum << " (want 1 +- 1e-12)\t\t"
+         << (passed ? "\033[32;49;1mPASS\033[0m" : "\033[31;49;1mFAIL\033[0m") << endl;
+    passed_all = passed_all & passed;
+
+    // --- 2. Gaussian kernel: symmetric, and FWHM within 5% of request ---
+    passed = (kernel.size() % 2 == 1);
+    for (int i = 0; i < (int)kernel.size() / 2; i++)
+    {
+        passed = passed && (kernel[i] == kernel[kernel.size() - 1 - i]);
+    }
+    cout << "Gaussian kernel symmetry:     " << kernel.size() << " points (odd, mirrored)\t\t"
+         << (passed ? "\033[32;49;1mPASS\033[0m" : "\033[31;49;1mFAIL\033[0m") << endl;
+    passed_all = passed_all & passed;
+
+    double fwhmMeasured = kernel_fwhm_samples(kernel) * dt;
+    passed = fabs(fwhmMeasured / tauFwhm - 1.0) < 0.05;
+    cout << "Gaussian kernel FWHM:         " << fwhmMeasured << " s (want " << tauFwhm
+         << " s +- 5%)\t"
+         << (passed ? "\033[32;49;1mPASS\033[0m" : "\033[31;49;1mFAIL\033[0m") << endl;
+    passed_all = passed_all & passed;
+
+    // --- 3. Degenerate Gaussian widths collapse to the identity kernel ---
+    vector<double> identity = get_gaussian(dt, 0.0);
+    passed = (identity.size() == 1) && (identity[0] == 1.0);
+    identity = get_gaussian(dt, -1.0);
+    passed = passed && (identity.size() == 1) && (identity[0] == 1.0);
+    cout << "Degenerate width -> identity: {1.0}\t\t\t\t\t"
+         << (passed ? "\033[32;49;1mPASS\033[0m" : "\033[31;49;1mFAIL\033[0m") << endl;
+    passed_all = passed_all & passed;
+
+    // --- 4. conv1d with the identity kernel is a no-op (no time shift) ---
+    {
+        vector<double> probe = {0.0, 1.0, 2.0, 3.0, 0.5, 0.0};
+        vector<double> conv = conv1d(probe, {1.0});
+        passed = (conv.size() == probe.size());
+        for (int i = 0; passed && i < (int)probe.size(); i++)
+        {
+            passed = passed && (conv[i] == probe[i]);
+        }
+        cout << "conv1d identity no-op:        same length, bitwise equal\t\t"
+             << (passed ? "\033[32;49;1mPASS\033[0m" : "\033[31;49;1mFAIL\033[0m") << endl;
+        passed_all = passed_all & passed;
+    }
+
+    // --- 5. conv1d conserves charge away from the edges ---
+    {
+        vector<double> impulse(2048, 0.0);
+        impulse[1024] = 1.0; // well clear of both edges
+        vector<double> conv = conv1d(impulse, kernel);
+        double convSum = 0.0;
+        for (int i = 0; i < (int)conv.size(); i++)
+        {
+            convSum += conv[i];
+        }
+        passed = (conv.size() == impulse.size()) && (fabs(convSum - 1.0) < 1e-12);
+        cout << "conv1d charge conservation:   " << convSum << " (want 1 +- 1e-12)\t\t"
+             << (passed ? "\033[32;49;1mPASS\033[0m" : "\033[31;49;1mFAIL\033[0m") << endl;
+        passed_all = passed_all & passed;
+    }
+
+    // Device under test for the fast shaper (J30035-like; only dt,
+    // tauRecovery and tauLoad matter to the shaper).
+    SiPM sipm(5676, 27.5, 24.5, tauRecovery, 0.0, 14e-15, 2.04, 0.46);
+    sipm.dt = dt;
+    sipm.tauLoad = tauLoad;
+
+    // --- 6. Fast shaping: zero net charge (AC coupling) over a long window ---
+    const int n = 60000; // 3 us >> 5*tauRecovery
+    vector<double> q(n, 0.0);
+    q[0] = 1.0; // unit charge impulse
+    vector<double> shaped = sipm.shape_fast(q);
+    double net = 0.0;
+    for (int i = 0; i < n; i++)
+    {
+        net += shaped[i];
+    }
+    passed = ((int)shaped.size() == n) && (fabs(net) < 1e-3);
+    cout << "Fast shaper net charge:       " << net << " (want |.| < 1e-3)\t"
+         << (passed ? "\033[32;49;1mPASS\033[0m" : "\033[31;49;1mFAIL\033[0m") << endl;
+    passed_all = passed_all & passed;
+
+    // --- 7. Fast shaping: matches the analytic bipolar impulse response ---
+    // h(t) = A * (e^{-t/tauL}/tauL - e^{-t/tauR}/tauR), A = tauR/(tauR-tauL).
+    // The discrete one-pole bins the response, so compare each output sample
+    // against h evaluated at the bin midpoint, scaled by dt (charge per step).
+    {
+        const double A = tauRecovery / (tauRecovery - tauLoad);
+        double hMax = 0.0, errMax = 0.0;
+        for (int i = 0; i < n; i++)
+        {
+            double t = (i + 0.5) * dt; // bin midpoint
+            double h = A * (exp(-t / tauLoad) / tauLoad - exp(-t / tauRecovery) / tauRecovery) * dt;
+            hMax = max(hMax, fabs(h));
+            errMax = max(errMax, fabs(shaped[i] - h));
+        }
+        double relErr = errMax / hMax;
+        passed = relErr < 5e-3;
+        cout << "Fast shaper vs analytic h(t): max rel err " << relErr << " (want < 5e-3)\t"
+             << (passed ? "\033[32;49;1mPASS\033[0m" : "\033[31;49;1mFAIL\033[0m") << endl;
+        passed_all = passed_all & passed;
+    }
+
+    // --- 8. Chunked fast shaping identical to one-shot (streaming state) ---
+    {
+        vector<double> chunked(n, 0.0);
+        sipm.reset_fast_shaper();
+        const int chunk = 777; // deliberately awkward chunk size
+        for (int off = 0; off < n; off += chunk)
+        {
+            int m = min(chunk, n - off);
+            sipm.shape_fast_chunk(q.data() + off, chunked.data() + off, (size_t)m);
+        }
+        passed = true;
+        for (int i = 0; i < n; i++)
+        {
+            passed = passed && (chunked[i] == shaped[i]);
+        }
+        cout << "Chunked == one-shot shaping:  bitwise equal across chunk joins\t\t"
+             << (passed ? "\033[32;49;1mPASS\033[0m" : "\033[31;49;1mFAIL\033[0m") << endl;
+        passed_all = passed_all & passed;
+    }
+
+    string prefix = passed_all ? "\033[32;49;1m" : "\033[31;49;1m";
+    string outStatus = passed_all ? "PASS\n" : "FAIL\a\n";
+    cout << prefix << BAR_STRING << endl;
+    cout << prefix << "TEST " << outStatus;
+    cout << prefix << "END TEST: Output Pulse Shaping" << endl;
+    cout << prefix << BAR_STRING << "\033[0m" << endl;
+    return passed_all;
+}

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -19,6 +19,7 @@
 #include <string>
 #include "performance.hpp"
 #include "current_accuracy.hpp"
+#include "shaping.hpp"
 
 using namespace std;
 
@@ -37,8 +38,10 @@ int main()
 
     bool passed = true;
 
-    passed = passed && TEST_performance();
-    passed = passed && TEST_currents();
+    // Deterministic shaping checks first; the Monte-Carlo tests follow.
+    passed = TEST_shaping() && passed;
+    passed = TEST_performance() && passed;
+    passed = TEST_currents() && passed;
 
     if (passed)
     {


### PR DESCRIPTION
## What

The CLI emitted only the bare avalanche charge train. `shape_output()` existed but was never called, and its Gaussian kernel was wrong (sigma conversion off by ~4×, unnormalised so charge was not conserved). This PR fixes the Gaussian and adds physically-motivated kernels for the J-Series **fast output** terminal, all length-preserving and selectable from the CLI.

- **`get_gaussian()`** — correct `sigma = (tauFwhm/dt)/(2·sqrt(2·ln2))`, symmetric ±4σ support, kernel normalised to unit sum (charge-conserving); degenerate widths return the identity kernel.
- **Bipolar fast-output shaper** — models the AC-coupled J-Series fast terminal: `out = A·(P_tauLoad − P_tauRecovery)` via two exact charge-conserving one-pole recursions. Streams chunk-by-chunk with state carried across chunks, so net charge is ~zero by construction. New optional JSON param `tauLoad` (seconds, default `2.0e-9`, back-compatible).
- **CLI** — `--shape/-S none|gaussian|fast|bench`:
  - `none` (default) — behaviour-identical to before.
  - `gaussian` — Gaussian FIR, FWHM = `tauFwhm` (idealised amplifier).
  - `fast` — bipolar fast-output kernel.
  - `bench` — `fast` then `gaussian`: the physical terminal followed by a ~Gaussian amplifier, i.e. what an oscilloscope capture of the real device looks like.
- **`examples/python/simspad.py`** — optional `tauLoad` kwarg, round-trips through the params JSON, back-compatible with old params files.

The reported `Ibias` is taken from the pre-shaping anode sum (the fast output integrates to ~zero by construction), so shaping does not perturb the bias-current readout.

## Tests (`test/shaping.hpp`, runs under `make test`)

```
Gaussian kernel sum:          1 (want 1 +- 1e-12)                  PASS
Gaussian kernel symmetry:     103 points (odd, mirrored)          PASS
Gaussian kernel FWHM:         1.5e-09 s (want 1.5e-09 s +- 5%)    PASS
conv1d identity no-op:        same length, bitwise equal          PASS
conv1d charge conservation:   1 (want 1 +- 1e-12)                 PASS
Fast shaper net charge:       5.23e-16 (want |.| < 1e-3)          PASS
Fast shaper vs analytic h(t): max rel err 2.79e-05 (want < 5e-3)  PASS
Chunked == one-shot shaping:  bitwise equal across chunk joins    PASS
```

Builds clean under `-pedantic-errors -Wall -Wextra -Werror`; the full existing test suite (nonlinearity / bias-current accuracy) still passes.

## Cross-validation

Cross-validated against the analytic kernel and an independent Python implementation (in the [sipm-eq-paper](https://github.com/WillMatthews/sipm-eq-paper) study that motivated this): shaped OOK per-bit Q agrees within 3%.

## Notes

Closes #26 (pulse-shaping code was Gaussian-only and the Gaussian was broken; this fixes it and adds the fast/bench kernels). Fully arbitrary user-supplied FIR kernels would be a natural further step if you want to keep that issue open for it.

A follow-up will contribute the ngspice equivalent circuit that the `fast` kernel was calibrated against (FWHM 1.46 ns vs datasheet 1.5 ns), so the kernel can be re-derived from a circuit model rather than hard-coded.