### PR TITLE
Increase LUT size to 200 and add spice kernel pipeline

### DIFF
--- a/src/sipm.cpp
+++ b/src/sipm.cpp
@@ -59,7 +59,9 @@ SiPM::SiPM(unsigned long numMicrocell_in, double vbias_in, double vBr_in, double
     microcellTimes = vector<double>{};        // microcell live time of last detection vector
     microcellTimes.reserve(numMicrocell + 8); // Prevent issues with free()
 
-    LUTSize = 20;                    // Look Up Table Size
+    LUTSize = 200;  // LUT size: 20 points biased the static transfer curve by up to
+                    // ~3% at deep saturation (linear-interp error in eta/V); 200 keeps
+                    // the bias below the MC noise floor (~0.1%) at negligible cost.
     tVecLUT.assign(LUTSize, 0.0);   // Preallocate LUT Time array
     pdeVecLUT.assign(LUTSize, 0.0); // Preallocate LUT PDE array
     vVecLUT.assign(LUTSize, 0.0);   // Preallocate LUT Voltage array
@@ -86,7 +88,9 @@ SiPM::SiPM(unsigned long numMicrocell_in, double vbias_in, double vBr_in, double
     microcellTimes = vector<double>{};        // microcell live time of last detection vector
     microcellTimes.reserve(numMicrocell + 8); // Prevent issues with free()
 
-    LUTSize = 20;                    // Look Up Table Size
+    LUTSize = 200;  // LUT size: 20 points biased the static transfer curve by up to
+                    // ~3% at deep saturation (linear-interp error in eta/V); 200 keeps
+                    // the bias below the MC noise floor (~0.1%) at negligible cost.
     tVecLUT.assign(LUTSize, 0.0);   // Preallocate LUT Time array
     pdeVecLUT.assign(LUTSize, 0.0); // Preallocate LUT PDE array
     vVecLUT.assign(LUTSize, 0.0);   // Preallocate LUT Voltage array
@@ -146,7 +150,9 @@ SiPM::SiPM(vector<double> svars)
     microcellTimes = vector<double>{};        // microcell live time of last detection vector
     microcellTimes.reserve(numMicrocell + 8); // Prevent issues with free()
 
-    LUTSize = 20;                    // Look Up Table Size
+    LUTSize = 200;  // LUT size: 20 points biased the static transfer curve by up to
+                    // ~3% at deep saturation (linear-interp error in eta/V); 200 keeps
+                    // the bias below the MC noise floor (~0.1%) at negligible cost.
     tVecLUT.assign(LUTSize, 0.0);   // Preallocate LUT Time array
     pdeVecLUT.assign(LUTSize, 0.0); // Preallocate LUT PDE array
     vVecLUT.assign(LUTSize, 0.0);   // Preallocate LUT Voltage array


### PR DESCRIPTION
## Summary
- Increase eta/V lookup table from 20 to 200 points for improved accuracy in the device model
- Add spice → kernel pipeline (spice_kernel) for computing --shape fast output constants from ngspice simulation

## Related work
These changes resolve the LUT discretisation bias (issue #12, ~0.5–2.9% in static cross-check) and provide a repeatable derivation of the fast-output shaping kernel from the device circuit (issue #15).

## Test plan
- [ ] Verify static curve cross-check with SimSPAD passes at ≤0.1% with the larger LUT
- [ ] Confirm existing stage scripts still produce consistent results
- [ ] Check spice_kernel generates consistent fast-output kernel parameters

🤖 Generated with [Claude Code](https://claude.com/claude-code)